### PR TITLE
add define.go & optimize serialization of bytes

### DIFF
--- a/lib/go-p2p/secret_connection.go
+++ b/lib/go-p2p/secret_connection.go
@@ -306,12 +306,11 @@ func shareAuthSignature(sc *SecretConnection, pubKey *crypto.PubKeyEd25519, sign
 			var buf bytes.Buffer
 			sgm := &authSigMessage{pubKey, signature}
 			sgm.writeBytes(&buf)
-			//fmt.Println("======", len(buf.Bytes()))
 			bys := buf.Bytes()
 			_, err1 = sc.Write(bys)
 		},
 		func() {
-			readBuffer := make([]byte, 104)
+			readBuffer := make([]byte, 100)
 			_, err2 = io.ReadFull(sc, readBuffer)
 			err2 = recvMsg.readBytes(bytes.NewReader(readBuffer))
 		})

--- a/xlib/def/define.go
+++ b/xlib/def/define.go
@@ -1,0 +1,10 @@
+package def
+
+const (
+	ChangeAddressSerialHeight = 15000
+
+	ElectionFrequency = 500
+)
+
+type INT = int64
+type HINT = int32

--- a/xlib/serialtool.go
+++ b/xlib/serialtool.go
@@ -1,0 +1,105 @@
+package xlib
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+)
+
+func uvarintSize(i uint64) int {
+	if i == 0 {
+		return 0
+	}
+	if i < 1<<8 {
+		return 1
+	}
+	if i < 1<<16 {
+		return 2
+	}
+	if i < 1<<24 {
+		return 3
+	}
+	if i < 1<<32 {
+		return 4
+	}
+	if i < 1<<40 {
+		return 5
+	}
+	if i < 1<<48 {
+		return 6
+	}
+	if i < 1<<56 {
+		return 7
+	}
+	return 8
+}
+
+func WriteVarint(w io.Writer, i int) error {
+	var negate = false
+	if i < 0 {
+		negate = true
+		i = -i
+	}
+	var size = uvarintSize(uint64(i))
+	var err error
+	if negate {
+		// e.g. 0xF1 for a single negative byte
+		err = BinWrite(w, uint8(size+0xF0))
+	} else {
+		err = BinWrite(w, uint8(size))
+	}
+	if err != nil {
+		return err
+	}
+	if size > 0 {
+		var buf [8]byte
+		binary.BigEndian.PutUint64(buf[:], uint64(i))
+		err = BinWrite(w, buf[(8-size):])
+	}
+	return err
+}
+
+func ReadByte(r io.Reader) (byte, error) {
+	var buf [1]byte
+	_, err := io.ReadFull(r, buf[:])
+	return buf[0], err
+}
+
+func ReadUint8(r io.Reader) (uint8, error) {
+	bys, err := ReadByte(r)
+	if err != nil {
+		return 0, err
+	}
+	return uint8(bys), nil
+}
+
+func ReadVarint(r io.Reader) (int, error) {
+	ui8, err := ReadUint8(r)
+	if err != nil {
+		return 0, err
+	}
+	var negate = false
+	if (ui8 >> 4) == 0xF {
+		negate = true
+		ui8 = ui8 & 0x0F
+	}
+	if ui8 > 8 {
+		return 0, errors.New("Varint overflow")
+	}
+	if ui8 == 0 {
+		if negate {
+			err = errors.New("Varint does not allow negative zero")
+		}
+		return 0, err
+	}
+	var buf [8]byte
+	_, err = io.ReadFull(r, buf[(8-ui8):])
+	if err != nil {
+		return 0, err
+	}
+	var i = int(binary.BigEndian.Uint64(buf[:]))
+	if negate {
+		return -i, nil
+	}
+	return i, nil
+}

--- a/xlib/tools.go
+++ b/xlib/tools.go
@@ -15,7 +15,6 @@
 package xlib
 
 import (
-	"bytes"
 	"encoding/binary"
 	"io"
 	"os"
@@ -32,15 +31,15 @@ func CheckItfcNil(itfc interface{}) bool {
 }
 
 func BinRead(reader io.Reader, data interface{}) error {
-	return binary.Read(reader, binary.LittleEndian, data)
+	return binary.Read(reader, binary.BigEndian, data)
 }
 
 func BinWrite(writer io.Writer, data interface{}) error {
-	return binary.Write(writer, binary.LittleEndian, data)
+	return binary.Write(writer, binary.BigEndian, data)
 }
 
 func ReadBytes(reader io.Reader) ([]byte, error) {
-	byLen, err := IntFrom4Bytes(reader)
+	byLen, err := ReadVarint(reader)
 	if err != nil {
 		return nil, err
 	}
@@ -50,27 +49,11 @@ func ReadBytes(reader io.Reader) ([]byte, error) {
 }
 
 func WriteBytes(writer io.Writer, bys []byte) error {
-	err := BinWrite(writer, uint32(len(bys)))
+	err := WriteVarint(writer, len(bys))
 	if err != nil {
 		return err
 	}
 	return BinWrite(writer, bys)
-}
-
-func IntFrom4Bytes(reader io.Reader) (int, error) {
-	var num uint32
-	if err := BinRead(reader, &num); err != nil {
-		return 0, err
-	}
-	return int(num), nil
-}
-
-func IntTo4Bytes(num int) ([]byte, error) {
-	var buf bytes.Buffer
-	if err := BinWrite(&buf, uint32(num)); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
 }
 
 func PathExists(path string) (bool, error) {

--- a/xlib/tools_test.go
+++ b/xlib/tools_test.go
@@ -1,7 +1,11 @@
 package xlib
 
 import (
+	"bytes"
 	"testing"
+
+	"github.com/Baptist-Publication/chorus-module/lib/ed25519"
+	crypto "github.com/Baptist-Publication/chorus-module/lib/go-crypto"
 )
 
 func TestSortInt64Slc(t *testing.T) {
@@ -14,5 +18,29 @@ func TestSortInt64Slc(t *testing.T) {
 			return
 		}
 		pre = slc[i]
+	}
+}
+
+func TestSerialBytes(t *testing.T) {
+	privKeyBytes := new([64]byte)
+	copy(privKeyBytes[:32], crypto.CRandBytes(32))
+	pubKeyBytes := ed25519.MakePublicKey(privKeyBytes)
+	set := (*pubKeyBytes)[:]
+	var wbuffer bytes.Buffer
+	if err := WriteBytes(&wbuffer, set); err != nil {
+		t.Error("writeBytes err:", err)
+		return
+	}
+	wbys := wbuffer.Bytes()
+
+	rbuffer := bytes.NewReader(wbys)
+	ret, err := ReadBytes(rbuffer)
+	if err != nil {
+		t.Error("readBytes err:", err)
+		return
+	}
+	//fmt.Printf("origin:%X\nwrite bytes:%X\nre-read bytes:%X\n", set, wbys, ret)
+	if string(ret) != string(set) {
+		t.Error("read error, not equal")
 	}
 }


### PR DESCRIPTION
- move agtypes.INT to def.INT
- optimize serialization of WriteBytes & ReadBytes in xlib,reduce length in p2p transaction